### PR TITLE
Implement Applications for Registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/chai": "^4.2.12",
     "@types/chai-http": "^4.2.0",
     "@types/express": "^4",
+    "@types/express-fileupload": "^1",
     "@types/jwt-simple": "^0.5.33",
     "@types/mime-types": "^2",
     "@types/mocha": "^8.0.3",
@@ -42,12 +43,14 @@
     "typescript": "^3.9.7"
   },
   "dependencies": {
+    "@types/node": "^14.14.10",
     "axios": "^0.21.0",
     "bcrypt": "^5.0.0",
     "class-validator": "^0.12.2",
     "client-oauth2": "^4.3.3",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
+    "express-fileupload": "^1.2.0",
     "jwt-simple": "^0.5.6",
     "morgan": "^1.10.0",
     "openapi-comment-parser": "^1.0.0",

--- a/src/controllers/applicationController.ts
+++ b/src/controllers/applicationController.ts
@@ -1,0 +1,127 @@
+import * as auth from '../middleware/authMiddleware';
+import {User} from '../entity/User';
+import {Application} from '../entity/Application';
+
+import {getManager} from 'typeorm';
+import {Request, Response} from 'express';
+import {validate} from 'class-validator';
+import app from '../server';
+
+import * as path from 'path';
+import * as fs from 'fs';
+
+const RESUME_ROOT = __dirname + '/../../resumes/';
+
+export const saveApplication = async (req: Request, res: Response) => {
+    const appRepo = getManager().getRepository(Application);
+
+    // Grab currently logged in user
+    const token = req.header('Authorization')?.split(' ')[1];
+    if(!token) {
+        res.sendStatus(401); // User was not properly authenticated...
+        return;
+    }
+
+    const user = await auth.getUserObjectFromToken(token, ['application']);
+    if(!user) {
+        res.sendStatus(401);
+        return;
+    }
+
+    if(user.application?.completed) {
+        res.status(400).send('User already has a completed application.');
+        return;
+    }
+    
+    const existingApp = user.application;
+    let appData = null;
+    if(req.body.body) {
+        appData = JSON.parse(req.body.body);
+    }
+
+    // If there's an existing one, update the fields. Otherwise, create a new one
+    let appToSave;
+    if(existingApp) {
+        appToSave = Object.assign(existingApp, appData);
+    } else {
+        appToSave = appRepo.create({...appData as Application});
+    }
+    
+    // Handle the resume. We're saving them to a resumes folder in the root of the project
+    if(req.files?.resume) {        
+        let resume = req.files.resume;
+        try {
+            const resumePath = await fs.promises.realpath(RESUME_ROOT) + '/' + appToSave.email + '.pdf';
+            await resume.mv(resumePath);
+            appToSave.resume = resumePath;
+        } catch (err) { 
+            res.status(500).send(err);
+            return;
+        }
+    }
+
+    let userToSave = user;
+    delete userToSave.application; // We need to delete the app so we don't write a null application
+    appToSave.user = userToSave
+    if(!appToSave.completed) {
+        appToSave.completed = false;
+    }
+
+    const errors = await validate(appToSave);
+    if(errors.length > 0) {
+        res.sendStatus(400);
+    } else {
+        try {
+            await appRepo.save(appToSave);
+            res.sendStatus(201);
+        } catch (error) {
+            res.status(400).send(error);
+        }
+    }
+}
+
+export const getApplicationForUser = async (req: Request, res: Response) => {
+    const token = req.header('Authorization')?.split(' ')[1];
+    if(!token) {
+        res.sendStatus(401);
+        return;
+    }
+
+    const user = await auth.getUserObjectFromToken(token, ['application']);
+    if(!user) {
+        res.sendStatus(401);
+        return;
+    }
+
+    if(user.application) {
+        // Remove the id and resume path
+        let {id, resume, ...app} = user.application;
+        res.status(200).send(user.application);
+    } else {
+        res.sendStatus(404);
+    }
+}
+
+export const getApplicationByUserId = async (req: Request, res: Response) => {
+    const userRepo = getManager().getRepository(User);
+    const user = await userRepo.findOne({uuid: req.params.userId});
+
+    if(!user) {
+        res.sendStatus(404);
+        return;
+    }
+
+    if(user.application) {
+        // Remove the id and resume path
+        let {id, resume, ...app} = user.application;
+        res.status(200).send(user.application);
+    } else {
+        res.sendStatus(404);
+    }
+}
+
+export const getAllApplications = async (req: Request, res: Response) => {
+    const appRepo = getManager().getRepository(Application);
+    const applications = await appRepo.find();
+    res.status(200).send(applications);
+}

--- a/src/entity/Application.ts
+++ b/src/entity/Application.ts
@@ -43,11 +43,15 @@ export class Application {
     numHackathons?: number;
 
     @Column({nullable: true})
-    siteUrl?: string;
+    personalSiteUrl?: string;
 
     // Stores the path to their resume
     @Column({nullable: true})
-    resume?: string;
+    resumePath?: string;
+
+    // Stores the uploaded name of their resume
+    @Column({nullable: true})
+    resumeName?: string;
 
     @OneToOne(() => User, user => user.application, {cascade: true})
     user!: User;

--- a/src/entity/Application.ts
+++ b/src/entity/Application.ts
@@ -1,0 +1,60 @@
+import {Column, PrimaryGeneratedColumn, Entity, BeforeInsert, BeforeUpdate, OneToOne} from 'typeorm';
+import { validateOrReject, IsDefined } from 'class-validator';
+
+import {User} from './User';
+
+@Entity()
+export class Application {
+
+    @PrimaryGeneratedColumn()
+    id!: number;
+
+    @Column()
+    completed!: boolean;
+
+    @Column({nullable: true})
+    firstName?: string;
+
+    @Column({nullable: true})
+    lastName?: string;
+
+    @Column({nullable: true})
+    pronouns?: string;
+
+    @Column({nullable: true})
+    email?: string;
+
+    @Column({nullable: true})
+    levelOfStudy?: string;
+
+    @Column({nullable: true})
+    program?: string;
+
+    @Column({nullable: true})
+    shortAnswer1?: string;
+
+    @Column({nullable: true})
+    shortAnswer2?: string;
+
+    @Column({nullable: true})
+    shortAnswer3?: string;
+
+    @Column({nullable: true})
+    numHackathons?: number;
+
+    @Column({nullable: true})
+    siteUrl?: string;
+
+    // Stores the path to their resume
+    @Column({nullable: true})
+    resume?: string;
+
+    @OneToOne(() => User, user => user.application, {cascade: true})
+    user!: User;
+
+    @BeforeInsert()
+    @BeforeUpdate()
+    async validate(): Promise<void> {
+        await validateOrReject(this);
+    }
+}

--- a/src/entity/User.ts
+++ b/src/entity/User.ts
@@ -1,5 +1,7 @@
-import {Column, PrimaryGeneratedColumn, Entity, BeforeInsert, BeforeUpdate} from 'typeorm';
+import {Column, PrimaryGeneratedColumn, Entity, BeforeInsert, BeforeUpdate, OneToOne, JoinColumn} from 'typeorm';
 import { validateOrReject, IsDefined, registerDecorator, ValidationArguments } from 'class-validator';
+
+import {Application} from './Application';
 
 export enum Role {
     Hacker,
@@ -53,6 +55,10 @@ export class User {
 
     @Column({nullable: true, type: 'varchar'})
     githubId?: string | null;
+
+    @OneToOne(() => Application, app => app.user)
+    @JoinColumn()
+    application?: Application | null;
 
     @BeforeInsert()
     @BeforeUpdate()

--- a/src/middleware/authMiddleware.ts
+++ b/src/middleware/authMiddleware.ts
@@ -194,6 +194,27 @@ export const getUserFromToken = (token: string): string|undefined => {
     return decodeJWT(token).session?.id;
 }
 
+/**
+ * Grabs user object from a token
+ * 
+ * @param token the token
+ * 
+ * @returns the user object 
+ */
+export const getUserObjectFromToken = async (token: string, relations?: string[]): Promise<User|undefined> => {
+    const userRepo = getManager().getRepository(User);
+    const uuid = getUserFromToken(token);
+    if(!uuid) return undefined;
+
+    // Verify that the user is properly authenticated
+    const valid = await verifyToken(token, 'access');
+    if(valid.result !== AuthTokenStatus.Valid) return undefined;
+
+    const user = await userRepo.findOne({uuid: uuid}, {relations: relations});
+    if(!user) return undefined;
+    return user;
+}
+
 // Middleware for verifying if a request is authenticated via a Bearer token in Authentication header
 export const authenticate = (role: Role): (req: Request, res: Response, next: NextFunction) => Promise<void> => {
 

--- a/src/routes/applications.ts
+++ b/src/routes/applications.ts
@@ -1,0 +1,50 @@
+import express from 'express';
+import * as application from '../controllers/applicationController';
+import * as auth from '../middleware/authMiddleware';
+
+import {Role} from '../entity/User';
+
+const router = express.Router();
+
+/**
+ * POST /application
+ * @tag Applications
+ * @summary Save an application
+ * @description Saves an application. Field validation to be done by front end. Pass in completed = true to "submit" an application
+ * @bodyContent {Application} application/json
+ * @bodyRequired
+ * @response 200 - Created
+ */
+router.post('/', application.saveApplication);
+
+/**
+ * GET /application
+ * @tag Applications
+ * @summary Get all applications
+ * @description Returns all applications. Must be logged in as an organizer
+ * @response 200 - An array of all applications
+ * @responseContent {Application[]} 200.application/json
+ */
+router.get('/', auth.authenticate(Role.Organizer), application.getAllApplications);
+
+/**
+ * GET /application/my
+ * @tag Applications
+ * @summary Get the current user's application
+ * @description Returns the current user's (i.e. logged in user's) application
+ * @response 200 - The current user's application
+ * @responseContent {Application} 200.application/json
+ */
+router.get('/my', application.getApplicationForUser);
+
+/**
+ * GET /application/{userId}
+ * @tag Applications
+ * @pathParam {string} userId - UUID of the user
+ * @summary Get the specified user's application 
+ * @response 200 - The specified user's application
+ * @responseContent {Application} 200.application/json
+ */
+router.get(':userId', auth.authenticate(Role.Organizer), application.getApplicationByUserId);
+
+export = router;

--- a/src/routes/components/application.yml
+++ b/src/routes/components/application.yml
@@ -1,0 +1,33 @@
+components:
+  schemas:
+    Application:
+      type: object
+      properties:
+        completed:
+          type: boolean
+        firstName:
+          type: string
+        lastName:
+          type: string
+        pronouns:
+          type: string
+        email:
+          type: string
+        levelOfStudy:
+          type: string
+        program:
+          type: string
+        shortAnswer1:
+          type: string
+        shortAnswer2:
+          type: string
+        shortAnswer3:
+          type: string 
+        numHackathons:
+          type: integer
+        siteUrl:
+          type: string
+        resume:
+          type: string
+      xml:
+        name: Application

--- a/src/routes/components/application.yml
+++ b/src/routes/components/application.yml
@@ -25,9 +25,9 @@ components:
           type: string 
         numHackathons:
           type: integer
-        siteUrl:
+        personalSiteUrl:
           type: string
-        resume:
+        resumeName:
           type: string
       xml:
         name: Application

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -7,6 +7,7 @@ import { Request, Response } from 'express';
 import status from './status';
 import user from './user';
 import auth from './auth';
+import applications from './applications';
 
 const router = express.Router();
 
@@ -18,5 +19,6 @@ router.get('/', (req: Request, res: Response) => {
 router.use('/status', status);
 router.use('/user', user);
 router.use('/auth', auth);
+router.use('/application', applications);
 
 export = router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ dotenv.config();
 import express from 'express';
 import morgan from 'morgan';
 import path from 'path';
+import fileUpload from 'express-fileupload';
 
 import routes from './routes/routes';
 import {createConnection} from 'typeorm';
@@ -30,6 +31,7 @@ const spec = openapi({cwd: path.join(__dirname,'../src')});
  */
 app.use(express.json({ limit: '50mb' }));
 app.use(morgan('tiny'));
+app.use(fileUpload());
 
 app.use(API_ROOT, routes);
 

--- a/tests/postman/Watershed.postman_collection.json
+++ b/tests/postman/Watershed.postman_collection.json
@@ -1032,7 +1032,7 @@
 							"formdata": [
 								{
 									"key": "body",
-									"value": "{\n    \"firstName\": \"Test\",\n    \"lastName\": \"Application\",\n    \"pronouns\": \"it\",\n    \"email\": \"test@test.com\",\n    \"levelOfStudy\": \"yes\",\n    \"program\": \"yes\",\n    \"shortAnswer1\": \"answer\",\n    \"shortAnswer2\": \"answer\",\n    \"shortAnswer3\": \"answer\",\n    \"numHackathons\": 1,\n    \"siteUrl\": \"no\",\n\"completed\": false\n}",
+									"value": "{\n    \"firstName\": \"Test\",\n    \"lastName\": \"Application\",\n    \"pronouns\": \"it\",\n    \"email\": \"test@test.com\",\n    \"levelOfStudy\": \"yes\",\n    \"program\": \"yes\",\n    \"shortAnswer1\": \"answer\",\n    \"shortAnswer2\": \"answer\",\n    \"shortAnswer3\": \"answer\",\n    \"numHackathons\": 1,\n    \"personalSiteUrl\": \"no\",\n\"completed\": false\n}",
 									"type": "text"
 								},
 								{
@@ -1084,7 +1084,7 @@
 									"    \"shortAnswer2\": \"answer\",\r",
 									"    \"shortAnswer3\": \"answer\",\r",
 									"    \"numHackathons\": 1,\r",
-									"    \"siteUrl\": \"no\",\r",
+									"    \"personalSiteUrl\": \"no\",\r",
 									"    \"completed\": false\r",
 									"}\r",
 									"\r",
@@ -1204,7 +1204,7 @@
 									"    \"shortAnswer2\": \"answer\",\r",
 									"    \"shortAnswer3\": \"answer\",\r",
 									"    \"numHackathons\": 1,\r",
-									"    \"siteUrl\": \"no\",\r",
+									"    \"personalSiteUrl\": \"no\",\r",
 									"    \"completed\": false\r",
 									"}\r",
 									"\r",
@@ -1265,7 +1265,7 @@
 									"    \"shortAnswer2\": \"answer\",\r",
 									"    \"shortAnswer3\": \"answer\",\r",
 									"    \"numHackathons\": 1,\r",
-									"    \"siteUrl\": \"no\",\r",
+									"    \"personalSiteUrl\": \"no\",\r",
 									"    \"completed\": false\r",
 									"}\r",
 									"\r",
@@ -1332,7 +1332,7 @@
 							"formdata": [
 								{
 									"key": "body",
-									"value": "{\n\"shortAnswer2\": \"anotherNewAnswer\",\n\"completed\": true\n}",
+									"value": "{\n\"shortAnswer2\": \"anotherNewAnswer\",\n\"resumePath\": \"\",\n\"resumeName\":\"\",\n\"completed\": true\n}",
 									"type": "text"
 								},
 								{
@@ -1363,6 +1363,20 @@
 				},
 				{
 					"name": "4.9 Can't Edit Submitted Application",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "79eeb29c-4c47-4535-bea9-d75603b97895",
+								"exec": [
+									"pm.test(\"Status code is 400\", function () {\r",
+									"    pm.response.to.have.status(400);\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
 					"request": {
 						"method": "POST",
 						"header": [
@@ -1429,8 +1443,9 @@
 									"    \"shortAnswer2\": \"anotherNewAnswer\",\r",
 									"    \"shortAnswer3\": \"answer\",\r",
 									"    \"numHackathons\": 1,\r",
-									"    \"siteUrl\": \"no\",\r",
-									"    \"completed\": true\r",
+									"    \"personalSiteUrl\": \"no\",\r",
+									"    \"completed\": true,\r",
+									"    \"resumeName\": \"\"\r",
 									"}\r",
 									"\r",
 									"pm.test(\"Data is correct\", function () {\r",

--- a/tests/postman/Watershed.postman_collection.json
+++ b/tests/postman/Watershed.postman_collection.json
@@ -726,6 +726,16 @@
 								],
 								"type": "text/javascript"
 							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "b812f1b4-1c2f-445d-a255-fec3ad3195c6",
+								"exec": [
+									"setTimeout(function(){}, [1000]);"
+								],
+								"type": "text/javascript"
+							}
 						}
 					],
 					"request": {
@@ -882,6 +892,576 @@
 							"path": [
 								"api",
 								"user"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		},
+		{
+			"name": "4. Applications",
+			"item": [
+				{
+					"name": "4.1 Create User",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "02517a1a-94f1-4277-ae33-da2f59d0c3dd",
+								"exec": [
+									"pm.test(\"Status code is 201\", () => {\r",
+									"    pm.response.to.have.status(201);\r",
+									"});\r",
+									"\r",
+									"pm.environment.set(\"userId\", pm.response.json().uuid);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"firstName\": \"Application\",\r\n    \"lastName\": \"Test\",\r\n    \"email\": \"app@test.com\",\r\n    \"password\": \"password\",\r\n    \"role\": 2\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{HOST}}/api/user",
+							"host": [
+								"{{HOST}}"
+							],
+							"path": [
+								"api",
+								"user"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "4.2 Login",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "d5e4f561-5954-4856-ad16-d5d7bd83fa17",
+								"exec": [
+									"const jsonData = pm.response.json();\r",
+									"\r",
+									"pm.test(\"Status code is 201\", () => {\r",
+									"    pm.response.to.have.status(200);\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Object should be returned\", () => {\r",
+									"    pm.expect(jsonData).to.be.an(\"object\");\r",
+									"    pm.expect(jsonData).to.not.be.empty;\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Access and Refresh Tokens are returned\", () => {\r",
+									"        pm.expect(jsonData).to.have.all.keys(\"refreshToken\", \"accessToken\");\r",
+									"});\r",
+									"\r",
+									"pm.environment.set(\"ACCESS_TOKEN\", jsonData.accessToken.token);\r",
+									"pm.environment.set(\"REFRESH_TOKEN\", jsonData.refreshToken.token);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"email\": \"app@test.com\",\r\n    \"password\": \"password\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{HOST}}/api/auth/login",
+							"host": [
+								"{{HOST}}"
+							],
+							"path": [
+								"api",
+								"auth",
+								"login"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "4.3 Create Application",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "50bf589c-ea09-440d-b8ff-f249260f5ffe",
+								"exec": [
+									"pm.test(\"Status code is 201\", function () {\r",
+									"    pm.response.to.have.status(201);\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{ACCESS_TOKEN}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "body",
+									"value": "{\n    \"firstName\": \"Test\",\n    \"lastName\": \"Application\",\n    \"pronouns\": \"it\",\n    \"email\": \"test@test.com\",\n    \"levelOfStudy\": \"yes\",\n    \"program\": \"yes\",\n    \"shortAnswer1\": \"answer\",\n    \"shortAnswer2\": \"answer\",\n    \"shortAnswer3\": \"answer\",\n    \"numHackathons\": 1,\n    \"siteUrl\": \"no\",\n\"completed\": false\n}",
+									"type": "text"
+								},
+								{
+									"key": "resume",
+									"type": "file",
+									"src": [],
+									"disabled": true
+								}
+							],
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{HOST}}/api/application",
+							"host": [
+								"{{HOST}}"
+							],
+							"path": [
+								"api",
+								"application"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "4.4 Get Application",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "85b18688-2176-4400-ab56-ccb3072b3466",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.response.to.have.status(200);\r",
+									"});\r",
+									"\r",
+									"const expected = {\r",
+									"    \"firstName\": \"Test\",\r",
+									"    \"lastName\": \"Application\",\r",
+									"    \"pronouns\": \"it\",\r",
+									"    \"email\": \"test@test.com\",\r",
+									"    \"levelOfStudy\": \"yes\",\r",
+									"    \"program\": \"yes\",\r",
+									"    \"shortAnswer1\": \"answer\",\r",
+									"    \"shortAnswer2\": \"answer\",\r",
+									"    \"shortAnswer3\": \"answer\",\r",
+									"    \"numHackathons\": 1,\r",
+									"    \"siteUrl\": \"no\",\r",
+									"    \"completed\": false\r",
+									"}\r",
+									"\r",
+									"pm.test(\"Data is correct\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    for(const key in expected) {\r",
+									"        pm.expect(jsonData[key]).to.eql(expected[key]);\r",
+									"    }\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{ACCESS_TOKEN}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{HOST}}/api/application/my",
+							"host": [
+								"{{HOST}}"
+							],
+							"path": [
+								"api",
+								"application",
+								"my"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "4.5 Edit Application",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "e7837e52-c84e-43d0-82ec-031372defe02",
+								"exec": [
+									"pm.test(\"Status code is 201\", function () {\r",
+									"    pm.response.to.have.status(201);\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{ACCESS_TOKEN}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "body",
+									"value": "{\n\"shortAnswer1\": \"newAnswer\"\n}",
+									"type": "text"
+								},
+								{
+									"key": "resume",
+									"type": "file",
+									"src": "/C:/Users/Ryan/Documents/Resume/RyanLyResume.pdf",
+									"disabled": true
+								}
+							],
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{HOST}}/api/application",
+							"host": [
+								"{{HOST}}"
+							],
+							"path": [
+								"api",
+								"application"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "4.6 Get Application (2)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "27b7e11e-0bde-4d92-99d3-a175f54aa69d",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.response.to.have.status(200);\r",
+									"});\r",
+									"\r",
+									"const expected = {\r",
+									"    \"firstName\": \"Test\",\r",
+									"    \"lastName\": \"Application\",\r",
+									"    \"pronouns\": \"it\",\r",
+									"    \"email\": \"test@test.com\",\r",
+									"    \"levelOfStudy\": \"yes\",\r",
+									"    \"program\": \"yes\",\r",
+									"    \"shortAnswer1\": \"newAnswer\",\r",
+									"    \"shortAnswer2\": \"answer\",\r",
+									"    \"shortAnswer3\": \"answer\",\r",
+									"    \"numHackathons\": 1,\r",
+									"    \"siteUrl\": \"no\",\r",
+									"    \"completed\": false\r",
+									"}\r",
+									"\r",
+									"pm.test(\"Data is correct\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    for(const key in expected) {\r",
+									"        pm.expect(jsonData[key]).to.eql(expected[key]);\r",
+									"    }\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{ACCESS_TOKEN}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{HOST}}/api/application/my",
+							"host": [
+								"{{HOST}}"
+							],
+							"path": [
+								"api",
+								"application",
+								"my"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "4.7 Get All Applications",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "4876735d-c161-4d10-be4d-0042e1a6d1b9",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.response.to.have.status(200);\r",
+									"});\r",
+									"\r",
+									"const expected = {\r",
+									"    \"firstName\": \"Test\",\r",
+									"    \"lastName\": \"Application\",\r",
+									"    \"pronouns\": \"it\",\r",
+									"    \"email\": \"test@test.com\",\r",
+									"    \"levelOfStudy\": \"yes\",\r",
+									"    \"program\": \"yes\",\r",
+									"    \"shortAnswer1\": \"newAnswer\",\r",
+									"    \"shortAnswer2\": \"answer\",\r",
+									"    \"shortAnswer3\": \"answer\",\r",
+									"    \"numHackathons\": 1,\r",
+									"    \"siteUrl\": \"no\",\r",
+									"    \"completed\": false\r",
+									"}\r",
+									"\r",
+									"pm.test(\"Data is correct\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    for(const key in expected) {\r",
+									"        pm.expect(jsonData[0][key]).to.eql(expected[key]);\r",
+									"    }\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"type": "text",
+								"value": "Bearer {{ACCESS_TOKEN}}"
+							}
+						],
+						"url": {
+							"raw": "{{HOST}}/api/application",
+							"host": [
+								"{{HOST}}"
+							],
+							"path": [
+								"api",
+								"application"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "4.8 Edit Application and Submit",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "ee8cb8b5-e8ed-4096-bd2f-baf1a25086f6",
+								"exec": [
+									"pm.test(\"Status code is 201\", function () {\r",
+									"    pm.response.to.have.status(201);\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"type": "text",
+								"value": "Bearer {{ACCESS_TOKEN}}"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "body",
+									"value": "{\n\"shortAnswer2\": \"anotherNewAnswer\",\n\"completed\": true\n}",
+									"type": "text"
+								},
+								{
+									"key": "resume",
+									"type": "file",
+									"src": [],
+									"disabled": true
+								}
+							],
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{HOST}}/api/application",
+							"host": [
+								"{{HOST}}"
+							],
+							"path": [
+								"api",
+								"application"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "4.9 Can't Edit Submitted Application",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"type": "text",
+								"value": "Bearer {{ACCESS_TOKEN}}"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "body",
+									"value": "{\n    \"firstName\": \"Test\",\n    \"lastName\": \"Application\",\n    \"pronouns\": \"it\",\n    \"email\": \"test@test.com\",\n    \"levelOfStudy\": \"yes\",\n    \"program\": \"yes\",\n    \"shortAnswer1\": \"answer\",\n    \"shortAnswer2\": \"answer\",\n    \"shortAnswer3\": \"answer\",\n    \"numHackathons\": 1,\n    \"siteUrl\": \"no\"\n}",
+									"type": "text"
+								},
+								{
+									"key": "resume",
+									"type": "file",
+									"src": [],
+									"disabled": true
+								}
+							],
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{HOST}}/api/application",
+							"host": [
+								"{{HOST}}"
+							],
+							"path": [
+								"api",
+								"application"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "4.10 Verify Final Application",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a6f544dc-a152-45c3-9484-8fa03b7805c0",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.response.to.have.status(200);\r",
+									"});\r",
+									"\r",
+									"const expected = {\r",
+									"    \"firstName\": \"Test\",\r",
+									"    \"lastName\": \"Application\",\r",
+									"    \"pronouns\": \"it\",\r",
+									"    \"email\": \"test@test.com\",\r",
+									"    \"levelOfStudy\": \"yes\",\r",
+									"    \"program\": \"yes\",\r",
+									"    \"shortAnswer1\": \"newAnswer\",\r",
+									"    \"shortAnswer2\": \"anotherNewAnswer\",\r",
+									"    \"shortAnswer3\": \"answer\",\r",
+									"    \"numHackathons\": 1,\r",
+									"    \"siteUrl\": \"no\",\r",
+									"    \"completed\": true\r",
+									"}\r",
+									"\r",
+									"pm.test(\"Data is correct\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    for(const key in expected) {\r",
+									"        pm.expect(jsonData[key]).to.eql(expected[key]);\r",
+									"    }\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"type": "text",
+								"value": "Bearer {{ACCESS_TOKEN}}"
+							}
+						],
+						"url": {
+							"raw": "{{HOST}}/api/application/my",
+							"host": [
+								"{{HOST}}"
+							],
+							"path": [
+								"api",
+								"application",
+								"my"
 							]
 						}
 					},

--- a/yarn.lock
+++ b/yarn.lock
@@ -227,6 +227,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/express-fileupload@npm:^1":
+  version: 1.1.5
+  resolution: "@types/express-fileupload@npm:1.1.5"
+  dependencies:
+    "@types/express": "*"
+  checksum: 7d1da1e5088f3d9a92353f16dcad5239940b7752d5f6fddfc92affa26d654196597472ddb31bb00af38ec86760978383fa8cca86c42d08b8d1a089fa0fd6fda4
+  languageName: node
+  linkType: hard
+
 "@types/express-serve-static-core@npm:*":
   version: 4.17.13
   resolution: "@types/express-serve-static-core@npm:4.17.13"
@@ -330,6 +339,13 @@ __metadata:
   version: 13.13.30
   resolution: "@types/node@npm:13.13.30"
   checksum: c5b6c51df0463e08cdf3f4ee0b424d2be26f3668549f9ecb10d70e07dda4db84cb7853e344ff0bbed667b1b1899e199cd9f632441c6e9fd4fb465c51640ce0df
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^14.14.10":
+  version: 14.14.10
+  resolution: "@types/node@npm:14.14.10"
+  checksum: b793aa15e8c08df50d0f77dc0fe7a93bc2e09bfa5a424841d4dba045d6ae8503b7ffe89b773ffe197c9b637c898bb22e78442e21ff4b33414d35160d9c3f8a9b
   languageName: node
   linkType: hard
 
@@ -1136,6 +1152,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"busboy@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "busboy@npm:0.3.1"
+  dependencies:
+    dicer: 0.3.0
+  checksum: acc5c3d2f806c1f43a7a9a342bb4aaaa1223bac81cf3ba35ae3cc999f4e3a2e1b6db2d3895a228a862efbbc7b6fb39a7252e830bb5943e1b4362caa221c868ea
+  languageName: node
+  linkType: hard
+
 "byte-length@npm:^1.0.2":
   version: 1.0.2
   resolution: "byte-length@npm:1.0.2"
@@ -1884,6 +1909,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dicer@npm:0.3.0":
+  version: 0.3.0
+  resolution: "dicer@npm:0.3.0"
+  dependencies:
+    streamsearch: 0.1.2
+  checksum: eb06a8c283287da1f0034cde3f2bafe8bbd70636d4c9b12783f36d919c88533d6d285e044197853e03c1a2ea5d68f8ebcf59d366bd873a4a91e5d370e9871ad7
+  languageName: node
+  linkType: hard
+
 "diff@npm:4.0.2, diff@npm:^4.0.1":
   version: 4.0.2
   resolution: "diff@npm:4.0.2"
@@ -2265,6 +2299,15 @@ __metadata:
   version: 4.0.7
   resolution: "eventemitter3@npm:4.0.7"
   checksum: 1fc12c7bc3b4194c50975827e72d56ff57c32b75a4c7dbf4d5eebf3c8371f6f1aad6799150b609de1b867c0d8a9885c08b6ca5e7e0dc437d6152f3063b2607dd
+  languageName: node
+  linkType: hard
+
+"express-fileupload@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "express-fileupload@npm:1.2.0"
+  dependencies:
+    busboy: ^0.3.1
+  checksum: 111226a4e3f631edd054ac7327e8f057987e67c3850b9b448470407c0f8f4775495cb5556b7d551a83c00c6f4617b7c923e98d07a0aab3ea4c9baf42e11fd1d3
   languageName: node
   linkType: hard
 
@@ -2823,11 +2866,13 @@ fsevents@~2.1.2:
     "@types/chai": ^4.2.12
     "@types/chai-http": ^4.2.0
     "@types/express": ^4
+    "@types/express-fileupload": ^1
     "@types/jwt-simple": ^0.5.33
     "@types/mime-types": ^2
     "@types/mocha": ^8.0.3
     "@types/morgan": ^1
     "@types/newman": ^5
+    "@types/node": ^14.14.10
     "@types/swagger-ui-express": ^4
     "@types/uuid": ^8
     "@typescript-eslint/eslint-plugin": ^3.6.1
@@ -2842,6 +2887,7 @@ fsevents@~2.1.2:
     dotenv: ^8.2.0
     eslint: ^7.5.0
     express: ^4.17.1
+    express-fileupload: ^1.2.0
     jwt-simple: ^0.5.6
     liquid-json: ^0.3.1
     mime-types: ^2.1.27
@@ -5778,6 +5824,13 @@ fsevents@~2.1.2:
     end-of-stream: ~1.1.0
     stream-to-array: ~2.3.0
   checksum: 1f26f85d571d94a308f9332c79f2652697f9893733e3a2aebca1aaaf4d2a0d0655150b8b0a88105256a50510d9e9b8a0b1e5d9139b464ee1f9285be3647c3b83
+  languageName: node
+  linkType: hard
+
+"streamsearch@npm:0.1.2":
+  version: 0.1.2
+  resolution: "streamsearch@npm:0.1.2"
+  checksum: f72befba95082d49be19cd4318112bc141f6cd7cbb201ee8079887f6f3cbcdf79c311977ce0eaa93d7d8c3e6b9727412f6177a87ced5b98d0fd4075723ad8eaf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Implements applications.

The following operations are supported:
* Create a new application
* Edit an unfinished application (note: edit/submit is the same endpoint, controlled by a 'completed' boolean in the application)
* Get the application for the currently logged in user
* Get the application for a specific user (organizer only)
* Get the applications for all users (organizer only)

Currently not much input validation is being done and is left for the front end. Let me know if that needs to change.

Closes #22 

