### PR TITLE
Save Discord usernames

### DIFF
--- a/src/controllers/discordController.ts
+++ b/src/controllers/discordController.ts
@@ -71,6 +71,10 @@ export const discordAuthCallback = async (req: Request, res: Response): Promise<
 
     const discordUser = await userRepo.findOne({email: response.data.email, discordId: response.data.id});
     if(discordUser) {
+        if(!discordUser.discordUsername) {
+            discordUser.discordUsername = response.data.username + '#' + response.data.discriminator;
+            await userRepo.save(discordUser);
+        }
         // User with this ID exists, log them in
         // Generate a new access token and refresh token for them
         const accessToken = await auth.generateToken(discordUser.uuid, 'access');
@@ -94,6 +98,7 @@ export const discordAuthCallback = async (req: Request, res: Response): Promise<
                 role: Role.Hacker,
                 email: response.data.email,
                 discordId: response.data.id,
+                discordUsername: response.data.username + '#' + response.data.discriminator,
                 confirmed: true // OAuth users automatically have a confirmed email (do we want this?)
             } as User);
 
@@ -159,6 +164,7 @@ export const discordLinkCallback = async (req: Request, res: Response): Promise<
                 res.status(400).send('This user already has a Discord account linked. Please unlink first, then try again.'); // Do we want this?
             } else {
                 user.discordId = response.data.id;
+                user.discordUsername = response.data.username + '#' + response.data.discriminator;
                 await userRepo.save(user);
                 res.sendStatus(200);
             }
@@ -184,6 +190,7 @@ export const unlinkDiscord = async (req: Request, res: Response): Promise<void> 
     const user = await userRepo.findOne({uuid: uuid});
     if(user) { 
         user.discordId = null; 
+        user.discordUsername = null;
         await userRepo.save(user);
         res.sendStatus(204);
     } else {

--- a/src/entity/User.ts
+++ b/src/entity/User.ts
@@ -50,6 +50,9 @@ export class User {
     @Column({nullable: true, type: 'varchar'})
     githubId?: string | null;
 
+    @Column({nullable: true, type: 'varchar'})
+    discordUsername?: string | null;
+
     @OneToOne(() => Application, app => app.user)
     @JoinColumn()
     application?: Application | null;


### PR DESCRIPTION
Saves users' Discord usernames on sign up or log in.

In the rare case where a user signed up with Discord before this feature was deployed, and logs in with a method other than Discord (i.e. they have a Discord ID but no Discord username), they should be directed to log in with their Discord again, since it's difficult to get the username otherwise.

Closes #40 